### PR TITLE
Update install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ first build and install all dependencies according to the instructions
 [here](https://github.com/ygina/sidekick/tree/main/deps).
 Our experiments were run on an m4.xlarge AWS instance with a 4-CPU Intel Xeon
 E5 processor and 16 GB memory, running Ubuntu 22.04, but it should be possible
-to adapt the instructions for any Linux machine. (These experiments have also
+to adapt the instructions for any x86_64 Linux machine. (These experiments have also
 been tested on a [CloudLab](https://cloudlab.us/) d710 node running Ubuntu 22.04.)
 Each figure in the paper has
 a corresponding script, and the instructions can be found

--- a/deps/install_deps.sh
+++ b/deps/install_deps.sh
@@ -45,7 +45,7 @@ git checkout sidekick
 cd $SIDEKICK_HOME/deps
 curl -O https://nginx.org/download/nginx-1.16.1.tar.gz
 tar xvzf nginx-1.16.1.tar.gz
-wget https://pari.math.u-bordeaux.fr/pub/pari/unix/pari-2.15.2.tar.gz
+wget https://pari.math.u-bordeaux.fr/pub/pari/OLD/2.15/pari-2.15.2.tar.gz
 tar xvzf pari-2.15.2.tar.gz
 git clone git@github.com:viveris/pepsal.git
 rm nginx-1.16.1.tar.gz pari-2.15.2.tar.gz


### PR DESCRIPTION
- Doesn't work on ARM: Quiche repo uses arch-specific _mm_lfence and _rdtsc Sidekick also uses _rdtsc

- Link to pari should go to OLD directory for consistent version. See: https://pari.math.u-bordeaux.fr/pub/pari/unix/README